### PR TITLE
HW: Kubernetes logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,3 +215,13 @@ kubectl apply -f servicemonitor.yaml
 Проверка:
 kubectl port-forward --namespace monitoring $(kubectl get pods  --namespace monitoring --selector=app.kubernetes.io/name=grafana --output=jsonpath="{.items..metadata.name}") 3000
 Пароль по умолчанию: "prom-operator", можно изменить сознанием values.yam
+
+
+# HW8 Monitoring
+
+1. Создал кластер K8s в GCP и развернул в нем HipsterShop
+2. Установил EFK и  Porometheus operator используя helm
+3. Так же используя helm, установил nginx-ingress и изменил конфигурацию для вывода логов в json
+4. Обновил релизы с учетом доступа к kibana, grafana, prometheus через полученный ip, запустил Fluent Bit
+5. Создал визуализации в kibana и сделал экспорт в файл
+7. Установил и настроил Loki

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ kubectl port-forward --namespace monitoring $(kubectl get pods  --namespace moni
 Пароль по умолчанию: "prom-operator", можно изменить сознанием values.yam
 
 
-# HW8 Monitoring
+# HW9 Monitoring
 
 1. Создал кластер K8s в GCP и развернул в нем HipsterShop
 2. Установил EFK и  Porometheus operator используя helm

--- a/kubernetes-logging/elasticsearch.values.yaml
+++ b/kubernetes-logging/elasticsearch.values.yaml
@@ -1,0 +1,8 @@
+tolerations:
+  - key: node-role
+    operator: Equal
+    value: infra
+    effect: NoSchedule
+
+nodeSelector:
+  cloud.google.com/gke-nodepool: infra-pool

--- a/kubernetes-logging/fluent-bit.values.yaml
+++ b/kubernetes-logging/fluent-bit.values.yaml
@@ -1,0 +1,21 @@
+backend:
+  type: es
+  es:
+    host: elasticsearch-master
+
+tolerations:
+- key: node-role
+  operator: Equal
+  value: infra
+  effect: NoSchedule
+
+rawConfig: |
+  @INCLUDE fluent-bit-service.conf
+  @INCLUDE fluent-bit-input.conf
+  @INCLUDE fluent-bit-filter.conf
+  @INCLUDE fluent-bit-output.conf
+  [FILTER]
+    Name modify
+    Match *
+    Remove time
+    Remove @timestamp 

--- a/kubernetes-logging/kibana.values.yaml
+++ b/kubernetes-logging/kibana.values.yaml
@@ -1,0 +1,8 @@
+ingress:
+  enabled: true
+  annotations: {
+    kubernetes.io/ingress.class: nginx
+  }
+  path: /
+  hosts:
+    - kibana.35.197.193.103.xip.io

--- a/kubernetes-logging/loki.values.yaml
+++ b/kubernetes-logging/loki.values.yaml
@@ -1,0 +1,6 @@
+promtail:
+  tolerations:
+  - key: node-role
+    operator: Equal
+    value: infra
+    effect: NoSchedule

--- a/kubernetes-logging/nginx-ingress.values.yaml
+++ b/kubernetes-logging/nginx-ingress.values.yaml
@@ -1,0 +1,32 @@
+controller:
+  replicaCount: 3
+
+  tolerations:
+    - key: node-role
+      operator: Equal
+      value: infra
+      effect: NoSchedule
+
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - nginx-ingress
+          topologyKey: kubernetes.io/hostname
+
+  nodeSelector:
+    cloud.google.com/gke-nodepool: infra-pool
+
+  config:
+    log-format-escape-json: "true"
+    log-format-upstream: >
+      {"time": "$time_iso8601", "remote_addr": "$proxy_protocol_addr", "x-forward-for": "$proxy_add_x_forwarded_for", "request_id": "$req_id","remote_user": "$remote_user", "bytes_sent": $bytes_sent, 
+      "request_time": $request_time, "status":$status, "vhost": "$host", "request_proto": "$server_protocol","path": "$uri", "request_query": "$args", "request_length": $request_length, 
+      "duration": $request_time, "method": "$request_method", "http_referrer": "$http_referer", "http_user_agent": "$http_user_agent"}
+

--- a/kubernetes-logging/prometheus-crd.sh
+++ b/kubernetes-logging/prometheus-crd.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+kubectl apply --validate=false -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+kubectl apply --validate=false -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+kubectl apply --validate=false -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+kubectl apply --validate=false -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+kubectl apply --validate=false -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+kubectl apply --validate=false -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml

--- a/kubernetes-logging/prometheus-operator.values.yaml
+++ b/kubernetes-logging/prometheus-operator.values.yaml
@@ -1,0 +1,27 @@
+alertmanager:
+  alertmanagerSpec:
+    tolerations: &tolerations
+    - key: node-role
+      operator: Equal
+      value: infra
+      effect: NoSchedule
+grafana:
+  additionalDataSources:
+  - name: Loki
+    access: proxy
+    type: loki
+    url: http://loki:3100/
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
+    path: /
+    hosts:
+    - grafana.35.197.193.103.xip.io
+  tolerations: *tolerations
+prometheus:
+  prometheusSpec:
+    serviceMonitorSelectorNilUsesHelmValues: false
+    tolerations: *tolerations
+prometheusOperator:
+  tolerations: *tolerations


### PR DESCRIPTION
# Выполнено ДЗ №9

 - [ ] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
1. Создал кластер K8s в GCP и развернул в нем HipsterShop
2. Установил EFK и  Porometheus operator используя helm
3. Так же используя helm, установил nginx-ingress и изменил конфигурацию для вывода логов в json
4. Обновил релизы с учетом доступа к kibana, grafana, prometheus через полученный ip, запустил Fluent Bit
5. Создал визуализации в kibana и сделал экспорт в файл
7. Установил и настроил Loki

### Установка HipsterShop
**Как запустить проект:**
`kubectl create ns microservices-demo`
`kubectl apply -f https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Logging/microservices-demo-without-resources.yaml -n microservices-demo`
**Как проверить работоспособность:**
`kubectl get pods -n microservices-demo -o wide`

### Установка Elasticsearch
**Как запустить проект:**
`helm repo add elastic https://helm.elastic.co`
`kubectl create ns observability`
`helm upgrade --install elasticsearch elastic/elasticsearch --namespace observability -f kubernetes-logging/elasticsearch.values.yaml`
**Как проверить работоспособность:**
`kubectl get pods -n observability -o wide -l chart=elasticsearch`

### Установка Kibana
**Как запустить проект:**
`helm upgrade --install kibana elastic/kibana --namespace observability -f kubernetes-logging/kibana.values.yaml`
**Как проверить работоспособность:**
`kubectl get pods -n observability -o wide -l release=kibana`
`curl -v kibana.35.197.193.103.xip.io`

### Установка Fluent-bit
**Как запустить проект:**
`helm upgrade --install fluent-bit stable/fluent-bit --namespace observability -f kubernetes-logging/fluent-bit.values.yaml`
**Как проверить работоспособность:**
`kubectl get pods -n observability -o wide -l release=fluent-bit`

### Установка nginx-ingress
**Как запустить проект:**
`helm repo add stable https://kubernetes-charts.storage.googleapis.com`
`kubectl create ns nginx-ingress`
`helm upgrade --install nginx-ingress stable/nginx-ingress --namespace=nginx-ingress --version=1.11.1 -f kubernetes-logging/nginx-ingress.values.yaml`
**Как проверить работоспособность:**
`kubectl get pods -n nginx-ingress -o wide`

### Мониторинг ElasticSearch
**Как запустить проект:**
`helm upgrade --install prometheus-operator stable/prometheus-operator --namespace observability --version 8.13.12 -f kubernetes-logging/prometheus-operator.values.yaml`
`helm upgrade --install elasticsearch-exporter stable/elasticsearch-exporter --namespace=observability --set es.uri=http://elasticsearch-master:9200 --set serviceMonitor.enabled=true`
**Как проверить работоспособность:**
`kubectl get pods --namespace observability -l release=prometheus-operator`
`kubectl get pods --namespace observability -l release=elasticsearch-exporter`

### Установка Loki
**Как запустить проект:**
`helm repo add loki https://grafana.github.io/loki/charts`
`helm upgrade --install loki loki/loki-stack --namespace observability -f kubernetes-logging/loki.values.yaml`
**Как проверить работоспособность:**
`kubectl get pod -n observability -l release=loki`

## PR checklist:
* [ x ] Выставлен label с темой домашнего задания